### PR TITLE
Fixed getRotMod returning nil

### DIFF
--- a/Physbone API/physBoneAPI.lua
+++ b/Physbone API/physBoneAPI.lua
@@ -154,7 +154,7 @@ local physBoneBase = {
 		end,
 	getRotMod =
 		function(self)
-			return self.upsideDown
+			return self.rotMod
 		end,
 	setVecMod =
 		function(self,val1,val2,val3)


### PR DESCRIPTION
Currently, `getRotMod` always returns nil, because it refers to the non-existent field `upsideDown`. (Probably an older name ?)