### PR TITLE
Fixed bad rotation on root meshes

### DIFF
--- a/Physbone API/physBoneAPI.lua
+++ b/Physbone API/physBoneAPI.lua
@@ -833,7 +833,9 @@ function physBone.physBoneRender(delta, context, curPhysBoneID)
 					local rot = part:getRot()
 
 					mat:translate(-pivot)
-						:rotate(rot.x,rot.y,rot.z)
+						:rotate(0, 0,rot.z)
+						:rotate(0, rot.y, 0)
+						:rotate(rot.x, 0, 0)
 						:translate(pivot)
 
 						:translate(-parentPivot)


### PR DESCRIPTION
I stumbled upon a case were meshes inside bones are not rotated correctly. This looks easy to reproduce but somehow I managed to dodge it on most of my bones:
- The mesh must be at the very root of the bone. Meshes inside sub-groups are not affected.
- The mesh must have a rotation on the X axis.
- The mesh must have a rotation on either the Y or Z axis.

![Blockbench](https://github.com/user-attachments/assets/26d24a5c-fc8f-45a9-8915-5f2053997aa0)
![figura1](https://github.com/user-attachments/assets/24a12123-19ec-4abf-bf9f-066bf124acad)
In this case here, the mesh looks like its Y and Z rotations were swapped.


Honnestly, I am not quite sure what is going on here. I found this fix through trial and error, by looking for places where I could change the order of rotations. Nevertheless, I can confirm this fix only affects this specific case. It does not change the behaviour of other bones that were already working properly.